### PR TITLE
remove java-style iterators

### DIFF
--- a/src/project_manager/ros_project.cpp
+++ b/src/project_manager/ros_project.cpp
@@ -295,13 +295,11 @@ void ROSProject::buildProjectTree(const Utils::FilePath projectFilePath, const Q
     const ProjectExplorer::FolderNode::FolderNodeFactory &factory = [](const Utils::FilePath &fn) { return std::make_unique<ROSFolderNode>(fn); };
 
     std::vector<std::unique_ptr<ProjectExplorer::FileNode>> childNodes;
-    QHashIterator<QString, ROSUtils::FolderContent> item(results.workspaceContent);
+    QHash<QString, ROSUtils::FolderContent>::const_iterator item = results.workspaceContent.constBegin();
     int cnt = 0;
     double max = results.workspaceContent.size();
-    while (item.hasNext())
+    while(item != results.workspaceContent.constEnd())
     {
-      item.next();
-
       if (item.value().files.empty()) {
         // This is required so empty directories show up in project tree
         Utils::FilePath empty_directory = Utils::FilePath::fromString(item.key());
@@ -325,6 +323,7 @@ void ROSProject::buildProjectTree(const Utils::FilePath projectFilePath, const Q
 
       cnt += 1;
       fi.setProgressValue(static_cast<int>(100.0 * static_cast<double>(cnt) / max));
+      ++item;
     }
 
     project_node->addNestedNodes(std::move(childNodes), Utils::FilePath(), factory);

--- a/src/project_manager/ros_utils.cpp
+++ b/src/project_manager/ros_utils.cpp
@@ -527,11 +527,9 @@ ROSUtils::PackageInfoMap ROSUtils::getWorkspacePackageInfo(const WorkspaceInfo &
     PackageInfoMap wsPackageInfo;
     QMap<QString, QString> packages =  ROSUtils::getWorkspacePackagePaths(workspaceInfo);
 
-    QMapIterator<QString, QString> it(packages);
-    while (it.hasNext())
+    for(const auto& it : packages)
     {
-        it.next();
-        Utils::FilePath pkgXml = Utils::FilePath::fromString(it.value()).pathAppended("package.xml");
+        Utils::FilePath pkgXml = Utils::FilePath::fromString(it).pathAppended("package.xml");
         ROSUtils::PackageInfo packageInfo;
         ROSPackageXmlParser pkgParser;
         if (pkgParser.parsePackageXml(pkgXml, packageInfo))


### PR DESCRIPTION
https://github.com/qt-creator/qt-creator/commit/1b4766e26c6bd522ec49237075669ac025c47b20
disabled these classes upstream, so the plugin should not use them either.

rebased for 4.11 as requested in #1.

Sorry for the slow response, I actually have my hands full taking care of two kids during the Corona-Lockdown, so I would have appreciated if you'd just picked it yourself. :smile: 